### PR TITLE
fix(Bugs identified during user testing #25): Fixed a few bugs

### DIFF
--- a/bot/embeds/templates/neverwinter/classesList.ts
+++ b/bot/embeds/templates/neverwinter/classesList.ts
@@ -111,7 +111,7 @@ export const getOptionsList = () => [
     value: ClassNames.CLERIC_DPS,
     default: false,
   },
-  { label: ClassNames.BARB_DPS, value: ClassNames.BARB_DPS, default: false },
+  { label: ClassNames.BARD_DPS, value: ClassNames.BARD_DPS, default: false },
   { label: ClassNames.BARD_HEAL, value: ClassNames.BARD_HEAL, default: false },
   {
     label: ClassNames.WARLOCK_DPS,

--- a/bot/embeds/templates/neverwinter/raid.ts
+++ b/bot/embeds/templates/neverwinter/raid.ts
@@ -102,9 +102,14 @@ export const raidBuilder = ({
               value: `Frozen`,
               default: false,
             },
+            {
+              label: `Dragonbone Blades`,
+              value: `Blades`,
+              default: false,
+            }
           ],
           min_values: 1,
-          max_values: 7,
+          max_values: 10,
           type: 3,
         },
       ],

--- a/modules/httpEventsProcessor/index.ts
+++ b/modules/httpEventsProcessor/index.ts
@@ -29,13 +29,22 @@ export const httpEventsHandler = async (
   const strBody = event.isBase64Encoded
     ? Buffer.from(eventBody, "base64").toString("utf8")
     : eventBody;
+  const parsedEventBody = JSON.parse(strBody);
   try {
-    const sqsSendResult = isValidDiscordInteraction ? await sqsClient.sendMessage({
-      QueueUrl: config.DISCORD_EVENTS_SQS,
-      MessageBody: strBody,
-    }) : false;
-  
-    logger.log("info", "Event queued", { config, strBody, sqsSendResult });
+    const sqsSendResult = isValidDiscordInteraction
+      ? await sqsClient.sendMessage({
+          QueueUrl: config.DISCORD_EVENTS_SQS,
+          MessageBody: strBody,
+          MessageGroupId: parsedEventBody.guild_id,
+        })
+      : false;
+
+    logger.log("info", "Event queued", {
+      config,
+      parsedEventBody,
+      sqsSendResult,
+      MessageGroupId: parsedEventBody?.guild_id,
+    });
     return (
       verifyResponse || {
         statusCode: 200,

--- a/pulumi/sqs/discordEvents.ts
+++ b/pulumi/sqs/discordEvents.ts
@@ -1,9 +1,11 @@
 import * as aws from "@pulumi/aws";
 import { discordEventsLambdaCallback } from "../lambdas/discordEventsProcessor";
-import { httpEventsProcessor } from "../lambdas/httpEventsProcessor";
+
 const discordEventsQueue = new aws.sqs.Queue("discordEvents", {
   visibilityTimeoutSeconds: 180,
   messageRetentionSeconds: 300,
+  fifoQueue: true,
+  contentBasedDeduplication: true
 });
 
 discordEventsQueue.onEvent(


### PR DESCRIPTION
* **Inconvenience for users on user interactions due to the nature of how interactions were managed on the SQS. Queue now changed to FIFO and duplicating interactions removed.**
* **Artifacts limit now changed from 7 to 10.**
* **New Artifact options added in (only applicable to newly created raids , existing ones would not have it)**

_More info on the bugs:_

A little more info on some interactions not being processed or being processed weirdly was essentially due to how the Interactions were processed internally. Before this patch all interactions that came in from the discord web hook was processed and immediately added to an [SQS queue ](https://aws.amazon.com/sqs/). Which did not grantee the order in which they arrived. This caused issues since in some rare occasions the latest interaction event was behind on queue rather than in front.
Which caused weird interactions for some Interactions like selections / button clicks.

This was however fixed by turning the queue to a FIFO queue which ensures the queue order remains the same order in which events are queued onto it. Also de-duplication is now enabled which eliminates processing of same event more than once. This essentially means a failed interaction would not be re tried. 

Below gives an idea of the differences between standard and FIFO queue.  

![image](https://user-images.githubusercontent.com/7686931/193045225-9d4ac9a3-1a65-4315-abec-533a9404fe93.png)

